### PR TITLE
Fix Linux build 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,10 @@ jobs:
       - name: Setup Linux Build Dependencies
         if: ${{ runner.os == 'Linux' }}
         run: sudo apt-get install ninja-build
+
+      - name: Run apt upgrade
+        if: runner.os == 'Linux'
+        run: sudo apt upgrade
         
       - name: Install required Linux packages
         if: runner.os == 'Linux'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,24 +13,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup Linux Build Dependencies
-        if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get install ninja-build
-
-      - name: Run apt update
-        if: runner.os == 'Linux'
-        run: sudo apt update
-
-      - name: Run apt update
-        if: runner.os == 'Linux'
-        run: sudo apt upgrade
-        
-      - name: Install required Linux packages
         if: runner.os == 'Linux'
         run: >
           sudo apt install -y mesa-common-dev libgl1-mesa-dev libglu1-mesa-dev 
           libxext-dev libibus-1.0-dev
           fcitx-libs-dev libudev-dev libunwind-dev 
-          libwayland-dev libxkbcommon-dev libpulse-dev libsndio-dev
+          libwayland-dev libxkbcommon-dev libpulse-dev libsndio-dev ninja-build
           
       - name: Setup macOS Build Dependencies
         if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,12 +15,23 @@ jobs:
       - name: Setup Linux Build Dependencies
         if: ${{ runner.os == 'Linux' }}
         run: sudo apt-get install ninja-build
+        
+      - name: Install required Linux packages
+        if: runner.os == 'Linux'
+        run: >
+          sudo apt install -y mesa-common-dev libgl1-mesa-dev libglu1-mesa-dev 
+          libxext-dev libibus-1.0-dev
+          fcitx-libs-dev libudev-dev libunwind-dev 
+          libwayland-dev libxkbcommon-dev libpulse-dev libsndio-dev
+          
       - name: Setup macOS Build Dependencies
         if: ${{ runner.os == 'macOS' }}
         run: brew install ninja
+
       - name: Setup Windows Build Dependencies
         if: ${{ runner.os == 'Windows' }}
         run: choco install ninja
+      
       - name: Build with autobuild
         uses: secondlife/action-autobuild@v3
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,10 @@ jobs:
         addrsize: ["64"]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Update apt
+        if: runner.os == 'Linux'
+        run: sudo apt update
+
       - name: Setup Linux Build Dependencies
         if: runner.os == 'Linux'
         run: >

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,11 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: sudo apt-get install ninja-build
 
-      - name: Run apt upgrade
+      - name: Run apt update
+        if: runner.os == 'Linux'
+        run: sudo apt upgrade
+
+      - name: Run apt update
         if: runner.os == 'Linux'
         run: sudo apt upgrade
         

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Run apt update
         if: runner.os == 'Linux'
-        run: sudo apt upgrade
+        run: sudo apt update
 
       - name: Run apt update
         if: runner.os == 'Linux'


### PR DESCRIPTION
Before the Linux build was not properly OpenGL 4.5 aware. Fix this by making sure the build VM has all the required dev packages.

@nat-goodspeed I have to shine your call sign over Linden Lab HQ again, you are the hero we need
